### PR TITLE
Add explicit nullability support

### DIFF
--- a/.detekt/detekt.yml
+++ b/.detekt/detekt.yml
@@ -102,7 +102,7 @@ complexity:
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
-    active: true
+    active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     thresholdInFiles: 11
     thresholdInClasses: 11

--- a/README.md
+++ b/README.md
@@ -98,4 +98,14 @@ val serializer =
 val myPref = flowSharedPreferences.getObject("key", serializer, defaultValue = TestObject(0))
 ```
 
+### Explicit nullability support
+
+By default, strings and objects (and string sets) can never be `null`, so consumers don't ever have to worry about 
+null checks. If you want to support nullable values, you can explicitly opt in by asking for the 
+nullable-friendly preference types:
+
+```kotlin
+val nullableStringPreference = flowSharedPreferences.getNullableString("key", defaultValue = null)
+```
+
 # ⁕

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableObjectPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableObjectPreferenceTest.kt
@@ -1,0 +1,53 @@
+package com.tfcporciuncula.tests
+
+import com.google.common.truth.Truth.assertThat
+import com.tfcporciuncula.flow.NullableObjectPreference
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NullableObjectPreferenceTest : BaseTest() {
+
+  private class TestObject(val id: Int)
+
+  private val serializer =
+    object : NullableObjectPreference.Serializer<TestObject?> {
+      override fun deserialize(serialized: String?) = serialized?.let { TestObject(it.toInt()) }
+      override fun serialize(value: TestObject?) = value?.id?.toString()
+    }
+
+  @Test fun testDefaultValues() {
+    val preference1 = flowSharedPreferences.getNullableObject("key", serializer, defaultValue = TestObject(0))
+    assertThat(preference1.get()!!.id).isEqualTo(0)
+
+    val preference2 = flowSharedPreferences.getNullableObject("key", serializer, defaultValue = null)
+    assertThat(preference2.get()).isNull()
+  }
+
+  @Test fun testSettingValues() {
+    val preference = flowSharedPreferences.getNullableObject("key", serializer, defaultValue = TestObject(-1))
+
+    preference.set(TestObject(100))
+    assertThat(preference.get()!!.id).isEqualTo(100)
+
+    runBlocking {
+      preference.setAndCommit(TestObject(2000))
+      assertThat(preference.get()!!.id).isEqualTo(2000)
+    }
+  }
+
+  @Test fun testSettingNullValues() {
+    val preference = flowSharedPreferences.getNullableObject("key", serializer, defaultValue = TestObject(-1))
+
+    preference.set(null)
+    assertThat(preference.get()!!.id).isEqualTo(-1)
+    assertThat(preference.isSet()).isFalse()
+
+    runBlocking {
+      preference.setAndCommit(null)
+      assertThat(preference.get()!!.id).isEqualTo(-1)
+      assertThat(preference.isSet()).isFalse()
+    }
+  }
+}

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringPreferenceTest.kt
@@ -1,0 +1,44 @@
+package com.tfcporciuncula.tests
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NullableStringPreferenceTest : BaseTest() {
+
+  @Test fun testDefaultValues() {
+    val preference1 = flowSharedPreferences.getNullableString("key", defaultValue = "abc")
+    assertThat(preference1.get()).isEqualTo("abc")
+
+    val preference2 = flowSharedPreferences.getNullableString("key", defaultValue = null)
+    assertThat(preference2.get()).isNull()
+  }
+
+  @Test fun testSettingValues() {
+    val preference = flowSharedPreferences.getNullableString("key")
+
+    preference.set("--")
+    assertThat(preference.get()).isEqualTo("--")
+
+    runBlocking {
+      preference.setAndCommit("x")
+      assertThat(preference.get()).isEqualTo("x")
+    }
+  }
+
+  @Test fun testSettingNullValues() {
+    val preference = flowSharedPreferences.getNullableString("key", defaultValue = "default")
+
+    preference.set(null)
+    assertThat(preference.get()).isEqualTo("default")
+    assertThat(preference.isSet()).isFalse()
+
+    runBlocking {
+      preference.setAndCommit(null)
+      assertThat(preference.get()).isEqualTo("default")
+      assertThat(preference.isSet()).isFalse()
+    }
+  }
+}

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringSetOfNullablesPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringSetOfNullablesPreferenceTest.kt
@@ -1,0 +1,47 @@
+package com.tfcporciuncula.tests
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NullableStringSetOfNullablesPreferenceTest : BaseTest() {
+
+  @Test fun testDefaultValues() {
+    val preference1 = flowSharedPreferences.getNullableStringSetOfNullables("key", defaultValue = setOf("a", "b"))
+    assertThat(preference1.get()).isEqualTo(setOf("a", "b"))
+
+    val preference2 = flowSharedPreferences.getNullableStringSetOfNullables("key", defaultValue = setOf("x", null, "a"))
+    assertThat(preference2.get()).isEqualTo(setOf("x", null, "a"))
+
+    val preference3 = flowSharedPreferences.getNullableStringSetOfNullables("key", defaultValue = null)
+    assertThat(preference3.get()).isNull()
+  }
+
+  @Test fun testSettingValues() {
+    val preference = flowSharedPreferences.getNullableStringSetOfNullables("key")
+
+    preference.set(setOf("bla", null, "bla"))
+    assertThat(preference.get()).isEqualTo(setOf("bla", null))
+
+    runBlocking {
+      preference.setAndCommit(emptySet())
+      assertThat(preference.get()).isEqualTo(emptySet<String>())
+    }
+  }
+
+  @Test fun testSettingNullValues() {
+    val preference = flowSharedPreferences.getNullableStringSetOfNullables("key", defaultValue = emptySet())
+
+    preference.set(null)
+    assertThat(preference.get()).isEqualTo(emptySet<String>())
+    assertThat(preference.isSet()).isFalse()
+
+    runBlocking {
+      preference.setAndCommit(null)
+      assertThat(preference.get()).isEqualTo(emptySet<String>())
+      assertThat(preference.isSet()).isFalse()
+    }
+  }
+}

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringSetPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/NullableStringSetPreferenceTest.kt
@@ -1,0 +1,44 @@
+package com.tfcporciuncula.tests
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NullableStringSetPreferenceTest : BaseTest() {
+
+  @Test fun testDefaultValues() {
+    val preference1 = flowSharedPreferences.getNullableStringSet("key", defaultValue = setOf("a", "b"))
+    assertThat(preference1.get()).isEqualTo(setOf("a", "b"))
+
+    val preference2 = flowSharedPreferences.getNullableStringSet("key", defaultValue = null)
+    assertThat(preference2.get()).isNull()
+  }
+
+  @Test fun testSettingValues() {
+    val preference = flowSharedPreferences.getNullableStringSet("key")
+
+    preference.set(setOf("bla", "bla"))
+    assertThat(preference.get()).isEqualTo(setOf("bla"))
+
+    runBlocking {
+      preference.setAndCommit(emptySet())
+      assertThat(preference.get()).isEqualTo(emptySet<String>())
+    }
+  }
+
+  @Test fun testSettingNullValues() {
+    val preference = flowSharedPreferences.getNullableStringSet("key", defaultValue = emptySet())
+
+    preference.set(null)
+    assertThat(preference.get()).isEqualTo(emptySet<String>())
+    assertThat(preference.isSet()).isFalse()
+
+    runBlocking {
+      preference.setAndCommit(null)
+      assertThat(preference.get()).isEqualTo(emptySet<String>())
+      assertThat(preference.isSet()).isFalse()
+    }
+  }
+}

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetOfNullablesPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetOfNullablesPreferenceTest.kt
@@ -6,18 +6,18 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class NullableStringSetPreferenceTest : BaseTest() {
+class StringSetOfNullablesPreferenceTest : BaseTest() {
 
   @Test fun testDefaultValues() {
-    val preference1 = flowSharedPreferences.getNullableStringSet("key", defaultValue = setOf("a, b"))
+    val preference1 = flowSharedPreferences.getStringSetOfNullables("key", defaultValue = setOf("a, b"))
     assertThat(preference1.get()).isEqualTo(setOf("a, b"))
 
-    val preference2 = flowSharedPreferences.getNullableStringSet("key", defaultValue = setOf("x", null, "a"))
+    val preference2 = flowSharedPreferences.getStringSetOfNullables("key", defaultValue = setOf("x", null, "a"))
     assertThat(preference2.get()).isEqualTo(setOf("x", null, "a"))
   }
 
   @Test fun testSettingValues() {
-    val preference = flowSharedPreferences.getNullableStringSet("key")
+    val preference = flowSharedPreferences.getStringSetOfNullables("key")
 
     preference.set(setOf("bla", null, "bla"))
     assertThat(preference.get()).isEqualTo(setOf("bla", null))

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetOfNullablesPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetOfNullablesPreferenceTest.kt
@@ -9,8 +9,8 @@ import org.junit.Test
 class StringSetOfNullablesPreferenceTest : BaseTest() {
 
   @Test fun testDefaultValues() {
-    val preference1 = flowSharedPreferences.getStringSetOfNullables("key", defaultValue = setOf("a, b"))
-    assertThat(preference1.get()).isEqualTo(setOf("a, b"))
+    val preference1 = flowSharedPreferences.getStringSetOfNullables("key", defaultValue = setOf("a", "b"))
+    assertThat(preference1.get()).isEqualTo(setOf("a", "b"))
 
     val preference2 = flowSharedPreferences.getStringSetOfNullables("key", defaultValue = setOf("x", null, "a"))
     assertThat(preference2.get()).isEqualTo(setOf("x", null, "a"))

--- a/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/tfcporciuncula/tests/StringSetPreferenceTest.kt
@@ -9,8 +9,8 @@ import org.junit.Test
 class StringSetPreferenceTest : BaseTest() {
 
   @Test fun testDefaultValues() {
-    val preference1 = flowSharedPreferences.getStringSet("key", defaultValue = setOf("a, b"))
-    assertThat(preference1.get()).isEqualTo(setOf("a, b"))
+    val preference1 = flowSharedPreferences.getStringSet("key", defaultValue = setOf("a", "b"))
+    assertThat(preference1.get()).isEqualTo(setOf("a", "b"))
 
     val preference2 = flowSharedPreferences.getStringSet("key", defaultValue = setOf("x", "y", "a"))
     assertThat(preference2.get()).isEqualTo(setOf("x", "y", "a"))

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/BasePreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/BasePreference.kt
@@ -2,7 +2,6 @@ package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.filter
@@ -12,7 +11,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 abstract class BasePreference<T>(
-  private val keyFlow: Flow<String?>,
+  private val keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val coroutineContext: CoroutineContext

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/BooleanPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/BooleanPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class BooleanPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Boolean,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/EnumPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/EnumPreference.kt
@@ -1,13 +1,12 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import java.lang.Enum.valueOf
 import kotlin.coroutines.CoroutineContext
 
 class EnumPreference<T : Enum<T>>(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val enumClass: Class<T>,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FloatPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FloatPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class FloatPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Float,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -43,6 +43,10 @@ class FlowSharedPreferences @JvmOverloads constructor(
     StringPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   @JvmOverloads
+  fun getNullableString(key: String, defaultValue: String? = null): Preference<String?> =
+    NullableStringPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
+
+  @JvmOverloads
   fun getStringSet(key: String, defaultValue: Set<String> = emptySet()): Preference<Set<String>> =
     StringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -54,8 +54,15 @@ class FlowSharedPreferences @JvmOverloads constructor(
   fun getNullableStringSet(key: String, defaultValue: Set<String?> = emptySet()): Preference<Set<String?>> =
     NullableStringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
-  fun <T : Any> getObject(key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T): Preference<T> =
+  fun <T : Any> getObject(
+    key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T
+  ): Preference<T> =
     ObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
+
+  fun <T> getNullableObject(
+    key: String, serializer: NullableObjectPreference.Serializer<T>, defaultValue: T
+  ): Preference<T> =
+    NullableObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
 
   inline fun <reified T : Enum<T>> getEnum(key: String, defaultValue: T): Preference<T> =
     EnumPreference(keyFlow, sharedPreferences, key, T::class.java, defaultValue, coroutineContext)

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -54,7 +54,7 @@ class FlowSharedPreferences @JvmOverloads constructor(
   fun getNullableStringSet(key: String, defaultValue: Set<String?> = emptySet()): Preference<Set<String?>> =
     NullableStringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
-  fun <T> getObject(key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T): Preference<T> =
+  fun <T : Any> getObject(key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T): Preference<T> =
     ObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
 
   inline fun <reified T : Enum<T>> getEnum(key: String, defaultValue: T): Preference<T> =

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -8,13 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlin.coroutines.CoroutineContext
 
+internal typealias KeyFlow = Flow<String?>
+
 @ExperimentalCoroutinesApi
 class FlowSharedPreferences @JvmOverloads constructor(
   val sharedPreferences: SharedPreferences,
   val coroutineContext: CoroutineContext = Dispatchers.IO
 ) {
 
-  val keyFlow: Flow<String?> = callbackFlow {
+  val keyFlow: KeyFlow = callbackFlow {
     val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key -> offer(key) }
     sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
     awaitClose { sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener) }

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -70,6 +70,7 @@ class FlowSharedPreferences @JvmOverloads constructor(
   ): Preference<T> =
     ObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
 
+  @JvmOverloads
   fun <T> getNullableObject(
     key: String,
     serializer: NullableObjectPreference.Serializer<T>,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -51,8 +51,8 @@ class FlowSharedPreferences @JvmOverloads constructor(
     StringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   @JvmOverloads
-  fun getNullableStringSet(key: String, defaultValue: Set<String?> = emptySet()): Preference<Set<String?>> =
-    NullableStringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
+  fun getStringSetOfNullables(key: String, defaultValue: Set<String?> = emptySet()): Preference<Set<String?>> =
+    StringSetOfNullablesPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   fun <T : Any> getObject(
     key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -63,12 +63,16 @@ class FlowSharedPreferences @JvmOverloads constructor(
     NullableStringSetOfNullablesPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   fun <T : Any> getObject(
-    key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T
+    key: String,
+    serializer: ObjectPreference.Serializer<T>,
+    defaultValue: T
   ): Preference<T> =
     ObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
 
   fun <T> getNullableObject(
-    key: String, serializer: NullableObjectPreference.Serializer<T>, defaultValue: T
+    key: String,
+    serializer: NullableObjectPreference.Serializer<T>,
+    defaultValue: T
   ): Preference<T> =
     NullableObjectPreference(keyFlow, sharedPreferences, key, serializer, defaultValue, coroutineContext)
 

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -51,8 +51,16 @@ class FlowSharedPreferences @JvmOverloads constructor(
     StringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   @JvmOverloads
+  fun getNullableStringSet(key: String, defaultValue: Set<String>? = null): Preference<Set<String>?> =
+    NullableStringSetPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
+
+  @JvmOverloads
   fun getStringSetOfNullables(key: String, defaultValue: Set<String?> = emptySet()): Preference<Set<String?>> =
     StringSetOfNullablesPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
+
+  @JvmOverloads
+  fun getNullableStringSetOfNullables(key: String, defaultValue: Set<String?>? = null): Preference<Set<String?>?> =
+    NullableStringSetOfNullablesPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
   fun <T : Any> getObject(
     key: String, serializer: ObjectPreference.Serializer<T>, defaultValue: T

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/FlowSharedPreferences.kt
@@ -62,6 +62,7 @@ class FlowSharedPreferences @JvmOverloads constructor(
   fun getNullableStringSetOfNullables(key: String, defaultValue: Set<String?>? = null): Preference<Set<String?>?> =
     NullableStringSetOfNullablesPreference(keyFlow, sharedPreferences, key, defaultValue, coroutineContext)
 
+  @JvmOverloads
   fun <T : Any> getObject(
     key: String,
     serializer: ObjectPreference.Serializer<T>,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/IntPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/IntPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class IntPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Int,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/LongPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/LongPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class LongPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Long,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableObjectPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableObjectPreference.kt
@@ -1,0 +1,31 @@
+package com.tfcporciuncula.flow
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+class NullableObjectPreference<T>(
+  keyFlow: KeyFlow,
+  private val sharedPreferences: SharedPreferences,
+  private val key: String,
+  private val serializer: Serializer<T>,
+  private val defaultValue: T,
+  private val coroutineContext: CoroutineContext
+) : BasePreference<T>(keyFlow, sharedPreferences, key, coroutineContext) {
+
+  interface Serializer<T> {
+
+    fun deserialize(serialized: String?): T
+
+    fun serialize(value: T): String?
+  }
+
+  override fun get() =
+    sharedPreferences.getString(key, null)?.let { serializer.deserialize(it) } ?: defaultValue
+
+  override fun set(value: T) =
+    sharedPreferences.edit().putString(key, serializer.serialize(value)).apply()
+
+  override suspend fun setAndCommit(value: T) =
+    withContext(coroutineContext) { sharedPreferences.edit().putString(key, serializer.serialize(value)).commit() }
+}

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringPreference.kt
@@ -1,0 +1,21 @@
+package com.tfcporciuncula.flow
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+class NullableStringPreference(
+  keyFlow: KeyFlow,
+  private val sharedPreferences: SharedPreferences,
+  private val key: String,
+  private val defaultValue: String?,
+  private val coroutineContext: CoroutineContext
+) : BasePreference<String?>(keyFlow, sharedPreferences, key, coroutineContext) {
+
+  override fun get() = sharedPreferences.getString(key, defaultValue)
+
+  override fun set(value: String?) = sharedPreferences.edit().putString(key, value).apply()
+
+  override suspend fun setAndCommit(value: String?) =
+    withContext(coroutineContext) { sharedPreferences.edit().putString(key, value).commit() }
+}

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetOfNullablesPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetOfNullablesPreference.kt
@@ -1,0 +1,21 @@
+package com.tfcporciuncula.flow
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+class NullableStringSetOfNullablesPreference(
+  keyFlow: KeyFlow,
+  private val sharedPreferences: SharedPreferences,
+  private val key: String,
+  private val defaultValue: Set<String?>?,
+  private val coroutineContext: CoroutineContext
+) : BasePreference<Set<String?>?>(keyFlow, sharedPreferences, key, coroutineContext) {
+
+  override fun get(): Set<String?>? = sharedPreferences.getStringSet(key, defaultValue)
+
+  override fun set(value: Set<String?>?) = sharedPreferences.edit().putStringSet(key, value).apply()
+
+  override suspend fun setAndCommit(value: Set<String?>?) =
+    withContext(coroutineContext) { sharedPreferences.edit().putStringSet(key, value).commit() }
+}

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetPreference.kt
@@ -1,0 +1,21 @@
+package com.tfcporciuncula.flow
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+class NullableStringSetPreference(
+  keyFlow: KeyFlow,
+  private val sharedPreferences: SharedPreferences,
+  private val key: String,
+  private val defaultValue: Set<String>?,
+  private val coroutineContext: CoroutineContext
+) : BasePreference<Set<String>?>(keyFlow, sharedPreferences, key, coroutineContext) {
+
+  override fun get(): Set<String>? = sharedPreferences.getStringSet(key, defaultValue)
+
+  override fun set(value: Set<String>?) = sharedPreferences.edit().putStringSet(key, value).apply()
+
+  override suspend fun setAndCommit(value: Set<String>?) =
+    withContext(coroutineContext) { sharedPreferences.edit().putStringSet(key, value).commit() }
+}

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/NullableStringSetPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class NullableStringSetPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Set<String?>,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/ObjectPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/ObjectPreference.kt
@@ -4,7 +4,7 @@ import android.content.SharedPreferences
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
-class ObjectPreference<T>(
+class ObjectPreference<T : Any>(
   keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
@@ -13,7 +13,7 @@ class ObjectPreference<T>(
   private val coroutineContext: CoroutineContext
 ) : BasePreference<T>(keyFlow, sharedPreferences, key, coroutineContext) {
 
-  interface Serializer<T> {
+  interface Serializer<T : Any> {
 
     fun deserialize(serialized: String): T
 

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/ObjectPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/ObjectPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class ObjectPreference<T>(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val serializer: Serializer<T>,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class StringPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: String,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringSetOfNullablesPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringSetOfNullablesPreference.kt
@@ -4,7 +4,7 @@ import android.content.SharedPreferences
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
-class NullableStringSetPreference(
+class StringSetOfNullablesPreference(
   keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,

--- a/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringSetPreference.kt
+++ b/flow-preferences/src/main/java/com/tfcporciuncula/flow/StringSetPreference.kt
@@ -1,12 +1,11 @@
 package com.tfcporciuncula.flow
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class StringSetPreference(
-  keyFlow: Flow<String?>,
+  keyFlow: KeyFlow,
   private val sharedPreferences: SharedPreferences,
   private val key: String,
   private val defaultValue: Set<String>,


### PR DESCRIPTION
Inspired by https://github.com/xmartlabs/flow-preferences/pull/1/files to fix https://github.com/tfcporciuncula/flow-preferences/issues/6

- Introduces `NullableStringPreference` so users can explicitly opt in for nullability support when they're working with strings -- `StringPreference` remains strict against nullables.
- Introduces `NullableObjectPreference` and changes `ObjectPreference` to not accept nullable values to keep things consistent.
- Renames the current `NullableStringSetPreference` to `StringSetOfNullablesPreference`, and introduces a new `NullableStringSetPreference` and `NullableStringSetOfNullablesPreference` for actual `null` set support.

There's some code repetition here, but things are still pretty simple so I'm fine with it. I like how the library is now extremely explicit about nulls and I'll probably add a new section about this on the readme if this gets merged.