### PR TITLE
Add support for mapping preferences type

### DIFF
--- a/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/MappedPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/MappedPreferenceTest.kt
@@ -1,0 +1,36 @@
+package com.fredporciuncula.flow.preferences.tests
+
+import com.fredporciuncula.flow.preferences.map
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class MappedPreferenceTest : BaseTest() {
+
+  @Test fun testDefaultValues() {
+    val preference1 = flowSharedPreferences.getString("key", defaultValue = "1000")
+      .map(String::toInt, Int::toString)
+
+    assertThat(preference1.get()).isEqualTo(1000)
+
+    val preference2 = flowSharedPreferences.getInt("key", defaultValue = 5000)
+      .map(Int::toString, String::toInt)
+
+    assertThat(preference2.get()).isEqualTo("5000")
+  }
+
+  @Test fun testSettingValues() {
+    val preference = flowSharedPreferences.getString("key")
+      .map(String::toInt, Int::toString)
+
+    preference.set(1000)
+    assertThat(preference.get()).isEqualTo(1000)
+
+    runBlocking {
+      preference.setAndCommit(5000)
+      assertThat(preference.get()).isEqualTo(5000)
+    }
+  }
+}

--- a/flow-preferences/src/main/java/com/fredporciuncula/flow/preferences/MappedPreferences.kt
+++ b/flow-preferences/src/main/java/com/fredporciuncula/flow/preferences/MappedPreferences.kt
@@ -1,0 +1,72 @@
+package com.fredporciuncula.flow.preferences
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.map
+
+/**
+ * Returns the preference parameters after applying the [mapper] to convert the output
+ * and [reverse] to convert the input back to original values.
+ * */
+fun <T, R> Preference<T>.map(
+    mapper: (T) -> R,
+    reverse: (R) -> T
+): Preference<R> = MappedPreference(this, mapper, reverse)
+
+/**
+ * Return the preference parameter mapped to the values in the given map
+ * */
+fun <T, R> Preference<T>.mapToEntries(entries: Map<T, R>): Preference<R> = map({
+    entries[it]
+        ?: entries[defaultValue]
+        ?: throw IllegalArgumentException("No such value '$it' in entries")
+}) {
+    entries.entries.associate { (k, v) -> v to k }[it]
+        ?: throw IllegalArgumentException("No such key '$it' in entries")
+}
+
+/**
+ * Return the preference parameter mapped to the values in the given pairs
+ * */
+fun <T, R> Preference<T>.mapToEntries(vararg entries: Pair<T, R>): Preference<R> =
+    mapToEntries(entries.associate { it })
+
+internal class MappedPreference<T, R>(
+    private val preference: Preference<T>,
+    private val mapper: (T) -> R,
+    private val reverse: (R) -> T
+) : Preference<R> {
+    override val defaultValue: R
+        get() = mapper(preference.defaultValue)
+    override val key: String
+        get() = preference.key
+
+    override fun asCollector(): FlowCollector<R> = object : FlowCollector<R> {
+        override suspend fun emit(value: R) {
+            preference.asCollector().emit(reverse(value))
+        }
+    }
+
+    override fun asFlow(): Flow<R> = preference.asFlow().map { mapper(it) }
+
+    override fun asSyncCollector(throwOnFailure: Boolean): FlowCollector<R> =
+        object : FlowCollector<R> {
+            override suspend fun emit(value: R) {
+                preference.asSyncCollector(throwOnFailure).emit(reverse(value))
+            }
+        }
+
+    override fun delete() = preference.delete()
+
+    override suspend fun deleteAndCommit(): Boolean = preference.deleteAndCommit()
+
+    override fun get(): R = mapper(preference.get())
+
+    override fun isNotSet(): Boolean = preference.isNotSet()
+
+    override fun isSet(): Boolean = preference.isSet()
+
+    override fun set(value: R) = preference.set(reverse(value))
+
+    override suspend fun setAndCommit(value: R): Boolean = preference.setAndCommit(reverse(value))
+}


### PR DESCRIPTION
By default, it is not possible to change the type of the preference until it has either been emitted by flow or a get operation is performed; The issue with this is either to create multiple functions or to expose the internal types. 

For example, some preferences are stored as String due to EditTextPreference not supporting numeric types; Either you add a lot of boilerplate to the code or map when getting the value of the preference. 

This adds `map` function to return a delegated preference that maps the preference to a new type based on the given function. This ensures that the actual implementation is abstracted from the perspective of the caller.

There is another function `mapEntries` which is a helper function since in most cases you might need to transform values to specific types or constants.