### PR TITLE
Add toString() serializers for ObjectPreference

### DIFF
--- a/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/NullableObjectToStringPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/NullableObjectToStringPreferenceTest.kt
@@ -1,0 +1,56 @@
+package com.fredporciuncula.flow.preferences.tests
+
+import com.fredporciuncula.flow.preferences.NullableStringSerializer
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NullableObjectToStringPreferenceTest : BaseTest() {
+
+  private data class TestObject(val int: Int, val string: String) {
+    override fun toString(): String = "$int,$string"
+  }
+
+  private fun parseTestObject(string: String?): TestObject? {
+    string ?: return null
+    val split = string.split(",")
+    return TestObject(
+      int = split[0].toInt(),
+      string = split[1],
+    )
+  }
+
+  private val serializer = NullableStringSerializer(::parseTestObject)
+
+  @Test fun testDefaultValues() {
+    val default = TestObject(int = 123, string = "abc")
+    val preference = flowSharedPreferences.getNullableObject("key", serializer, default)
+    assertThat(preference.get()).isEqualTo(default)
+  }
+
+  @Test fun testSettingValues() {
+    val default = TestObject(int = 123, string = "abc")
+    val preference = flowSharedPreferences.getNullableObject(key = "key", serializer, default)
+
+    val newValue = TestObject(int = 456, string = "def")
+    preference.set(newValue)
+    assertThat(preference.get()).isEqualTo(newValue)
+  }
+
+  @Test fun testSettingNullValues() {
+    val default = TestObject(int = 123, string = "abc")
+    val preference = flowSharedPreferences.getNullableObject("key", serializer, default)
+
+    preference.set(null)
+    assertThat(preference.get()).isEqualTo(default)
+    assertThat(preference.isSet()).isFalse()
+
+    runBlocking {
+      preference.setAndCommit(null)
+      assertThat(preference.get()).isEqualTo(default)
+      assertThat(preference.isSet()).isFalse()
+    }
+  }
+}

--- a/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/ObjectToStringPreferenceTest.kt
+++ b/flow-preferences-tests/src/androidTest/java/com/fredporciuncula/flow/preferences/tests/ObjectToStringPreferenceTest.kt
@@ -1,0 +1,39 @@
+package com.fredporciuncula.flow.preferences.tests
+
+import com.fredporciuncula.flow.preferences.StringSerializer
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ObjectToStringPreferenceTest : BaseTest() {
+
+  private data class TestObject(val int: Int, val string: String) {
+    override fun toString(): String = "$int,$string"
+  }
+
+  private fun parseTestObject(string: String): TestObject {
+    val split = string.split(",")
+    return TestObject(
+      int = split[0].toInt(),
+      string = split[1],
+    )
+  }
+
+  private val serializer = StringSerializer(::parseTestObject)
+
+  @Test fun testDefaultValues() {
+    val default = TestObject(int = 123, string = "abc")
+    val preference = flowSharedPreferences.getObject("key", serializer, default)
+    assertThat(preference.get()).isEqualTo(default)
+  }
+
+  @Test fun testSettingValues() {
+    val default = TestObject(int = 123, string = "abc")
+    val preference = flowSharedPreferences.getObject(key = "key", serializer, default)
+
+    val newValue = TestObject(int = 456, string = "def")
+    preference.set(newValue)
+    assertThat(preference.get()).isEqualTo(newValue)
+  }
+}

--- a/flow-preferences/src/main/java/com/fredporciuncula/flow/preferences/Serializers.kt
+++ b/flow-preferences/src/main/java/com/fredporciuncula/flow/preferences/Serializers.kt
@@ -13,3 +13,15 @@ interface NullableSerializer<T> {
   fun deserialize(serialized: String?): T?
   fun serialize(value: T?): String?
 }
+
+/** Allows for the simple case where the class [T] is serialized to string using the [toString] method override. */
+fun interface StringSerializer<T : Any> : Serializer<T> {
+  override fun serialize(value: T): String = value.toString()
+}
+
+/**
+ * Allows for the simple case where the nullable class [T] is serialized to string using the [toString] method override.
+ */
+fun interface NullableStringSerializer<T : Any> : NullableSerializer<T> {
+  override fun serialize(value: T?): String? = value?.toString()
+}


### PR DESCRIPTION
I find myself adding this in most of my projects these days, so I figured I'd throw it back upstream as a little utility for a common use case (for me at least). It's not a functional change - just a shortcut.

Also added tests!